### PR TITLE
feat: add lix command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,14 @@ tracing-subscriber = { version = "0.3" }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 
+[[bin]]
+name = "nix-forecast"
+path = "src/main.rs"
+
+[[bin]]
+name = "lix-forecast"
+path = "src/main.rs"
+
 [lints.clippy]
 cargo = "warn"
 complexity = "warn"


### PR DESCRIPTION
As of Lix 2.93, the `lix-command` feature allows extending the `lix` CLI
with subcommands. Let's support them

https://lix.systems/blog/2025-05-06-lix-2.93-release/
