### PR TITLE
use symlink for lix-forecast command & document

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,14 +34,6 @@ tracing-subscriber = { version = "0.3" }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
 
-[[bin]]
-name = "nix-forecast"
-path = "src/main.rs"
-
-[[bin]]
-name = "lix-forecast"
-path = "src/main.rs"
-
 [lints.clippy]
 cargo = "warn"
 complexity = "warn"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ nix-forecast -c ".#nixosConfigurations.myMachine"
 nix-forecast -c ".#darwinConfigurations.myMac"
 ```
 
+### As a Lix subcommand
+
+> [!NOTE]
+> Requires Lix >= 2.93
+
+```sh
+lix forecast nixpkgs#hello
+```
+
 ## Why?
 
 Finding out if paths are cached can be a bit troublesome in Nix, with commands like `nix build --dry-run`

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -45,6 +45,8 @@ rustPlatform.buildRustPackage rec {
       --bash completions/nix-forecast.bash \
       --fish completions/nix-forecast.fish \
       --zsh completions/_nix-forecast
+
+    ln -s $out/bin/{n,l}ix-forecast
   '';
 
   env = {


### PR DESCRIPTION
Basically reverts 60eecb1a574a77e02fb4c596cabbd3c105c22650

It's better to have a symlink than literally two binaries
